### PR TITLE
Add properties to SingleProbeResponse and FullProbeResponse classes

### DIFF
--- a/data_types.py
+++ b/data_types.py
@@ -60,6 +60,11 @@ class SingleProbeResponse:
         self.domain = domain
         self.resolver = resolver
 
+    @property
+    def sld_tld_key(self) -> str:
+        """Return the second-level domain and top-level domain parts only (e.g. damcraft.de, without www.)"""
+        return ".".join(self.domain.split(".")[-2:])
+
     def __str__(self):
         return f"{self.domain} - {self.resolver}: {self.response.name} ({self.duration}ms)"
 
@@ -69,6 +74,16 @@ class FullProbeResponse:
         self.responses = responses
         self.final_result = final_result
 
+    @property
+    def sld_tld_sorted(self) -> dict[str, list[SingleProbeResponse]]:
+        """Return the responses grouped by second-level domain and top-level domain"""
+        grouped = {}
+        for response in self.responses:
+            key = response.sld_tld_key
+            if key not in grouped:
+                grouped[key] = []
+            grouped[key].append(response)
+        return grouped
 
 class ResolverHealth(Enum):
     REACHABLE = 1


### PR DESCRIPTION
- Added `sld_tld_key` property to `SingleProbeResponse` to extract second-level and top-level domain.
- Added `sld_tld_sorted` property to `FullProbeResponse` to group responses by second-level and top-level domain.

The idea is to then be able to list entries by "github.com" instead of "subdomain.github.com", which I think makes the output less cluttered. Maybe all the different subdomains can be listed in a separate column.

Doing the full implementation would have been a bit time consuming for me right now, but take it or leave it ^^
This here I was able to do in a few minutes. I have no idea how I'd have done this in vue (does not seem like a good idea really) 